### PR TITLE
Test the size of data being unmarshalled matches exactly

### DIFF
--- a/bls12.go
+++ b/bls12.go
@@ -68,7 +68,7 @@ const (
 // Unmarshal G1 or G2 point.
 func GUnmarshal(p G, in []byte) (res []byte) {
 	size := p.GetSize()
-	if len(in) < size {
+	if !(len(in) == size || len(in) == 2*size) {
 		return nil
 	}
 	var bin = make([]byte, size)


### PR DESCRIPTION
This fixes issue #2 